### PR TITLE
[nl-NL] Translate radio

### DIFF
--- a/businesses.xml
+++ b/businesses.xml
@@ -398,6 +398,7 @@
 
     <Entry Id="menu_crime_commited_suggestion">
         <String xml:lang="en-US">Shows you the list of your most recent crimes.</String>
+        <String xml:lang="nl-NL">Laat je de lijst zien van jouw meest recente misdaden.</String>
     </Entry>
 
     <!-- ========================= -->
@@ -635,10 +636,12 @@
 
     <Entry Id="menu_drugdealer_calls_description">
         <String xml:lang="en-US">View recent calls for a drug dealer.</String>
+        <String xml:lang="nl-NL">Bekijk de meeste recente drugdealer oproepen.</String>
     </Entry>
 
     <Entry Id="menu_drugdealer_recentsales_description">
         <String xml:lang="en-US">View your sales in the current session.</String>
+        <String xml:lang="nl-NL">Overzicht van bestellingen in huidige sessie.</String>
     </Entry>
 
     <!-- ========================= -->
@@ -703,6 +706,7 @@
 
     <Entry Id="menu_mechanic_services_description">
         <String xml:lang="en-US">Manage your services.</String>
+        <String xml:lang="nl-NL">Beheer je diensten.</String>
     </Entry>
 
     <Entry Id="menu_mechanic_services_request_subtitle">
@@ -736,6 +740,7 @@
 
     <Entry Id="menu_mechanic_calls_description">
         <String xml:lang="en-US">View recent calls for a mechanic.</String>
+        <String xml:lang="nl-NL">Bekijk de meeste recente monteur oproepen.</String>
     </Entry>
 
     <Entry Id="menu_mechanic_recentsales_subtitle">
@@ -755,6 +760,7 @@
 
     <Entry Id="menu_mechanic_recentsales_description">
         <String xml:lang="en-US">View your sales in the current session.</String>
+        <String xml:lang="nl-NL">Overzicht van bestellingen in huidige sessie.</String>
     </Entry>
 
     <Entry Id="menu_mechanic_available_subtitle">
@@ -1226,7 +1232,8 @@
     </Entry>
 
     <Entry Id="menu_paramedic_calls_description">
-        <String xml:lang="en-US">View recent calls.</String>
+        <String xml:lang="en-US">View recent calls for EMS.</String>
+        <String xml:lang="nl-NL">Bekijk recente ambulance oproepen.</String>
     </Entry>
 
     <!-- ========================= -->
@@ -1265,7 +1272,8 @@
     </Entry>
 
     <Entry Id="menu_policeofficer_calls_description">
-        <String xml:lang="en-US">View recent calls.</String>
+        <String xml:lang="en-US">View recent calls for police.</String>
+        <String xml:lang="nl-NL">Bekijk de meeste recente politie oproepen.</String>
     </Entry>
 
     <!-- ========================= -->
@@ -1325,7 +1333,7 @@
     <Entry Id="menu_radio_title">
         <String xml:lang="en-US">Radio</String>
         <String xml:lang="it-IT">Radio</String>
-        <String xml:lang="nl-NL">Radio</String>
+        <String xml:lang="nl-NL">Portofoon</String>
         <String xml:lang="es-ES">Radio</String>
         <String xml:lang="pt-BR">Rádio</String>
         <String xml:lang="ar-001">راديو</String>
@@ -1339,58 +1347,72 @@
 
     <Entry Id="menu_radio_use_subtitle">
         <String xml:lang="en-US">Use your radio.</String>
+        <String xml:lang="nl-NL">Gebruik je portofoon.</String>
     </Entry>
 
     <Entry Id="menu_radio_power">
         <String xml:lang="en-US">Power</String>
+        <String xml:lang="nl-NL">Status</String>
     </Entry>
 
     <Entry Id="menu_radio_channel">
         <String xml:lang="en-US">Channel</String>
+        <String xml:lang="nl-NL">Kanaal</String>
     </Entry>
 
     <Entry Id="menu_radio_volume">
         <String xml:lang="en-US">Volume</String>
+        <String xml:lang="nl-NL">Volume</String>
     </Entry>
 
     <Entry Id="radio_suggestion">
         <String xml:lang="en-US">Opens the radio menu.</String>
+        <String xml:lang="nl-NL">Opent het portofoon menu.</String>
     </Entry>
 
     <Entry Id="radio_text_suggestion">
         <String xml:lang="en-US">Send a text message over your current radio.</String>
+        <String xml:lang="nl-NL">Verstuur een tekstbericht over het huidige portofoon kanaal.</String>
     </Entry>
 
     <Entry Id="radio_text_suggestion_message">
         <String xml:lang="en-US">Message</String>
+        <String xml:lang="nl-NL">Bericht</String>
     </Entry>
 
     <Entry Id="radio_text_suggestion_content">
         <String xml:lang="en-US">The content of the message to send.</String>
+        <String xml:lang="nl-NL">Inhoud van het bericht dat je wilt versturen.</String>
     </Entry>
 
     <Entry Id="radio_not_available">
         <String xml:lang="en-US">There are no available radio channels for you.</String>
+        <String xml:lang="nl-NL">Er zijn geen portofoon kanalen beschikbaar voor jou.</String>
     </Entry>
 
     <Entry Id="radio_feature_notification">
         <String xml:lang="en-US">~y~NEW! ~s~You can now send text in radio channels: prefix your message with an ~b~exclamation mark ~s~(~b~!~s~) to use this feature!</String>
+        <String xml:lang="nl-NL">~y~NIEUW! ~s~Je kunt nu tekstberichten versturen in portofoon kanalen: voeg een ~b~uitroepteken ~s~(~b~!~s~) toe aan het begin van je bericht om deze functie te gebruiken!</String>
     </Entry>
 
     <Entry Id="radio_on">
         <String xml:lang="en-US">~g~ON</String>
+        <String xml:lang="nl-NL">~g~AAN</String>
     </Entry>
 
     <Entry Id="radio_off">
         <String xml:lang="en-US">~r~OFF</String>
+        <String xml:lang="nl-NL">~r~UIT</String>
     </Entry>
 
     <Entry Id="radio_mute">
         <String xml:lang="en-US">~r~Mute</String>
+        <String xml:lang="nl-NL">~r~Dempen</String>
     </Entry>
 
     <Entry Id="radio_channel_none">
         <String xml:lang="en-US">~r~None</String>
+        <String xml:lang="nl-NL">~r~Geen</String>
     </Entry>
     
     <!-- ========================= -->

--- a/imenu.xml
+++ b/imenu.xml
@@ -507,7 +507,7 @@
     <Entry Id="imenu_job_descr_police">
         <String xml:lang="en-US">Use your radio and view recent calls.</String>
         <String xml:lang="pl-PL">Użyj krótkofalówki i podejrzyj ostatnie zawołania.</String>
-        <String xml:lang="nl-NL">Gebruik je radio en bekijk recente meldingen.</String>
+        <String xml:lang="nl-NL">Gebruik je portofoon en bekijk recente meldingen.</String>
         <String xml:lang="tr-TR">Telsizinizi kullanın ve son çağrıları görüntüleyin.</String>
         <String xml:lang="de-DE">Benutze dein Funkgerät und zeige die letzten Anrufe an.</String>
         <String xml:lang="it-IT">Utilizza la tua radio e visualizza le chiamate recenti.</String>
@@ -525,7 +525,7 @@
     <Entry Id="imenu_job_descr_paramedic">
         <String xml:lang="en-US">Use your radio and view recent calls.</String>
         <String xml:lang="pl-PL">Użyj krótkofalówki i podejrzyj ostatnie zawołania.</String>
-        <String xml:lang="nl-NL">Gebruik je radio en bekijk recente meldingen.</String>
+        <String xml:lang="nl-NL">Gebruik je portofoon en bekijk recente meldingen.</String>
         <String xml:lang="tr-TR">Telsizinizi kullanın ve son çağrıları görüntüleyin.</String>
         <String xml:lang="de-DE">Benutze dein Funkgerät und zeige die letzten Anrufe an.</String>
         <String xml:lang="it-IT">Utilizza la tua radio e visualizza le chiamate recenti.</String>

--- a/main.xml
+++ b/main.xml
@@ -211,6 +211,7 @@
 
     <Entry Id="inventory_space_hint">
         <String xml:lang="en-US">Use, drop or give some items away to make space.</String>
+        <String xml:lang="nl-NL">Gebruik, drop of geef spullen weg om ruimte te maken.</String>
     </Entry>
 
     <Entry Id="cant_purchase_that_amount">

--- a/vehicles.xml
+++ b/vehicles.xml
@@ -412,5 +412,6 @@
 
     <Entry Id="error_creating_vehicle">
         <String xml:lang="en-US">~r~Unable to create vehicle.</String>
+        <String xml:lang="nl-NL">~r~Fout bij spawnen van voertuig.</String>
     </Entry>
 </Entries>


### PR DESCRIPTION
[nl-NL] Translate radio in businesses. Using "portofoon" everywhere for consistency.
[en-US] Specify EMS and Police for recent calls descriptions to be consistent with drug dealer/EMS calls.