### PR TITLE
[en-US] Remove extra "-suffix from sendwaypoint_player_received

### DIFF
--- a/main.xml
+++ b/main.xml
@@ -1492,7 +1492,7 @@
     </Entry>
 
     <Entry Id="sendwaypoint_player_received">
-        <String xml:lang="en-US">You shared your ~p~waypoint ~s~with {0}."</String>
+        <String xml:lang="en-US">You shared your ~p~waypoint ~s~with {0}.</String>
         <String xml:lang="nl-NL">Je hebt je ~p~GPS-bestemming ~s~gedeeld met {0}</String>
         <String xml:lang="it-IT">Hai condiviso il tuo ~p~waypoint ~s~con {0}.</String>
         <String xml:lang="fr-FR">Tu as partagé ton ~p~point de repère ~s~avec {0}.</String>


### PR DESCRIPTION
The source entry for this string seems to have an extra " at the end. This PR fixes that.